### PR TITLE
Remove Slash to prevent 405

### DIFF
--- a/resources/js/components/IndexField.vue
+++ b/resources/js/components/IndexField.vue
@@ -29,7 +29,7 @@ export default {
   methods: {
     onClick() {
       axios
-        .post("/nova-vendor/jackabox/nova-duplicate/", {
+        .post("/nova-vendor/jackabox/nova-duplicate", {
           model: this.field.model ? this.field.model : "",
           id: this.field.id ? this.field.id : "",
           resource: this.field.resource ? this.field.resource : "",


### PR DESCRIPTION
Hello,

This should fix #5 

Because there is a slash and the URL is not a folder, Laravel redirects the URL permanently, which results in an `405 Method Not Allowed`.