### PR TITLE
Go directly to edit page

### DIFF
--- a/src/Http/Controllers/DuplicateController.php
+++ b/src/Http/Controllers/DuplicateController.php
@@ -47,7 +47,7 @@ class DuplicateController extends Controller
         return [
             'status' => 200,
             'message' => 'Done',
-            'destination' => config('nova.url') . config('nova.path') . '/resources/' . $request->resource . '/' . $newModel->id
+            'destination' => config('nova.url') . config('nova.path') . '/resources/' . $request->resource . '/' . $newModel->id . '/edit'
         ];
     }
 }


### PR DESCRIPTION
According to [your gif](https://novapackages.com/packages/jackabox/nova-duplicate-field) you should return to the edit page when copying an item.

Yet this didn't happen to me, so I've added this functionality. Let me know what you think.