### PR TITLE
Update DuplicateController.php

### DIFF
--- a/src/Http/Controllers/DuplicateController.php
+++ b/src/Http/Controllers/DuplicateController.php
@@ -54,7 +54,7 @@ class DuplicateController extends Controller
         return [
             'status' => 200,
             'message' => 'Done',
-            'destination' => url(config('nova.path') . '/resources/' . $request->resource . '/' . $newModel->id)
+            'destination' => url(config('nova.path') . '/resources/' . $request->resource . 's/' . $newModel->id)
         ];
     }
 }


### PR DESCRIPTION
A standard laravel path uses plural for specifying the resource, like localhost/resources/myresources/1 instead of  localhost/resources/myresource/1
Calling the path with singular resources leads to 404, because the page does not exist.